### PR TITLE
2. Skipping tests: Acorn, UDP, Demo service (merge after "Adding tests" PR)

### DIFF
--- a/tests/build-and-deploy/build-and-deploy.sh
+++ b/tests/build-and-deploy/build-and-deploy.sh
@@ -20,7 +20,7 @@ do
     imgID=$($moth build Starbase --instance $instID --nacl $naclID --tag $tag --waitAndPrint)
     # Deploy
     cmdOut+=$($moth deploy $instID $imgID --wait)
-    # Check if the instance now reports this new nacl:
+    # Check if the instance now runs the built image and that it reports the given tag:
     cmdOutImgID=$($moth inspect-instance $instID -o json | jq -r '.imageId')
     cmdOutTag=$($moth inspect-instance $instID -o json | jq -r '.tag')
     if [[ "$cmdOutImgID" == *"$imgID"* ]] && [[ "$cmdOutTag" == *"$tag"* ]]; then

--- a/tests/build-and-deploy/build-and-deploy.sh
+++ b/tests/build-and-deploy/build-and-deploy.sh
@@ -1,0 +1,44 @@
+# build and deploy script
+# Script used for checking that building an image and deploying it to an instance (live update) works
+set -e
+
+moth="{{.MothershipBinPathAndName}}"
+instAlias={{.OriginalAlias}}
+instID=$($moth inspect-instance $instAlias -o id)
+naclID=$($moth push-nacl tests/deploy/interface.nacl -o id)
+tagBase="image"
+
+sent=0
+received=0
+
+# Build and deploy 20 times
+for i in {1..20}
+do
+    tag="$tagBase-$i"
+    sent=$[$sent + 1]
+    # Build
+    imgID=$($moth build Starbase --instance $instID --nacl $naclID --tag $tag --waitAndPrint)
+    # Deploy
+    cmdOut+=$($moth deploy $instID $imgID --wait)
+    # Check if the instance now reports this new nacl:
+    cmdOutImgID=$($moth inspect-instance $instID -o json | jq -r '.imageId')
+    cmdOutTag=$($moth inspect-instance $instID -o json | jq -r '.tag')
+    if [[ "$cmdOutImgID" == *"$imgID"* ]] && [[ "$cmdOutTag" == *"$tag"* ]]; then
+        received=$[$received + 1]
+    fi
+done
+
+# If none of the commands above failed it means that we were successful
+rate=0.1
+avg=0
+
+jq  --arg dataSent $sent \
+    --arg dataReceived $received \
+    --arg dataRate $rate \
+    --arg dataAvg $avg \
+    --arg dataFull "$cmdOut" \
+    '. | .["sent"]=($dataSent|tonumber) |
+    .["received"]=($dataReceived|tonumber) |
+    .["rate"]=($dataRate|tonumber) |
+    .["avg"]=($dataAvg|tonumber) |
+    .["raw"]=$dataFull'<<<'{}'

--- a/tests/build-and-deploy/interface.nacl
+++ b/tests/build-and-deploy/interface.nacl
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/build-and-deploy/testspec.json
+++ b/tests/build-and-deploy/testspec.json
@@ -1,0 +1,7 @@
+{
+    "hostcommandscript": "build-and-deploy.sh",
+    "deploy": false,
+    "level1": 1,
+    "level2": 2,
+    "level3": 3
+}

--- a/tests/deploy/deploy.sh
+++ b/tests/deploy/deploy.sh
@@ -18,12 +18,11 @@ do
     sent=$[$sent + 1]
     # Deploy
     cmdOut+=$($moth deploy $instID $imgID --wait)
-    # Check if the instance now reports this new nacl:
+    # Check if the instance now runs the image (note that this will be the same imageId every time):
     cmdOut+=$($moth inspect-instance $instID -o json | jq -r '.imageId')
     if [[ "$cmdOut" == *"$imgID"* ]]; then
         received=$[$received + 1]
     fi
-    sleep 0.2
 done
 
 # If none of the commands above failed it means that we were successful

--- a/tests/deploy/deploy.sh
+++ b/tests/deploy/deploy.sh
@@ -1,0 +1,42 @@
+# deploy script
+# Script used for checking that deploying an image to an instance (live update) works
+set -e
+
+moth="{{.MothershipBinPathAndName}}"
+instAlias={{.OriginalAlias}}
+instID=$($moth inspect-instance $instAlias -o id)
+naclID=$($moth push-nacl tests/deploy/interface.nacl -o id)
+# Build an image to deploy to the instance
+imgID=$($moth build Starbase --instance $instID --nacl $naclID --waitAndPrint)
+
+sent=0
+received=0
+
+# Deploy 100 times
+for i in {1..100}
+do
+    sent=$[$sent + 1]
+    # Deploy
+    cmdOut+=$($moth deploy $instID $imgID --wait)
+    # Check if the instance now reports this new nacl:
+    cmdOut+=$($moth inspect-instance $instID -o json | jq -r '.imageId')
+    if [[ "$cmdOut" == *"$imgID"* ]]; then
+        received=$[$received + 1]
+    fi
+    sleep 0.2
+done
+
+# If none of the commands above failed it means that we were successful
+rate=0.1
+avg=0
+
+jq  --arg dataSent $sent \
+    --arg dataReceived $received \
+    --arg dataRate $rate \
+    --arg dataAvg $avg \
+    --arg dataFull "$cmdOut" \
+    '. | .["sent"]=($dataSent|tonumber) |
+    .["received"]=($dataReceived|tonumber) |
+    .["rate"]=($dataRate|tonumber) |
+    .["avg"]=($dataAvg|tonumber) |
+    .["raw"]=$dataFull'<<<'{}'

--- a/tests/deploy/interface.nacl
+++ b/tests/deploy/interface.nacl
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/deploy/testspec.json
+++ b/tests/deploy/testspec.json
@@ -1,0 +1,7 @@
+{
+    "hostcommandscript": "deploy.sh",
+    "deploy": false,
+    "level1": 1,
+    "level2": 2,
+    "level3": 3
+}

--- a/tests/load-balancer/nping.sh
+++ b/tests/load-balancer/nping.sh
@@ -1,9 +1,8 @@
-# Connect to apache server running on client4 (TCP)
-# Basically: nping --tcp-connect -p 8080 10.100.0.160
+# Basically: nping --tcp-connect -p 90 10.100.0.30
 
 # Prerequisite:
 # Run 'docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4' on
-# lotto-client4 (10.100.0.160)
+# lotto-client3 (10.100.0.150) and lotto-client4 (10.100.0.160)
 
 sent=1000
 rate=100 # Requests pr second, higher than 5 requires sudo

--- a/tests/panics/panicking_service/service.cpp
+++ b/tests/panics/panicking_service/service.cpp
@@ -1,7 +1,6 @@
 // This file is a part of the IncludeOS unikernel - www.includeos.org
 //
-// Copyright 2015 Oslo and Akershus University College of Applied Sciences
-// and Alfred Bratterud
+// Copyright 2018 IncludeOS AS, Oslo, Norway
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/skip-acorn/acorn_service/CMakeLists.txt
+++ b/tests/skip-acorn/acorn_service/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+# IncludeOS install location
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
+endif()
+
+# Use toolchain (if needed)
+include($ENV{INCLUDEOS_PREFIX}/includeos/pre.service.cmake)
+
+include(dependencies.cmake)
+
+# Name of your project
+project (acorn_service)
+
+# Human-readable name of your service
+set(SERVICE_NAME "IncludeOS Acorn Web Service")
+
+# Name of your service binary
+set(BINARY       "acorn_service")
+
+# Source files to be linked with OS library parts to form bootable image
+set(SOURCES
+  service.cpp fs/acorn_fs.cpp
+  )
+
+#
+# Service CMake options
+# (uncomment to enable)
+#
+
+# MISC:
+
+# To add your own include paths:
+set(LOCAL_INCLUDES
+  "app/"
+  ${BUCKET_DIR}
+  )
+
+# Adding memdisk (expects my.disk to exist in current dir):
+# set(MEMDISK ${CMAKE_SOURCE_DIR}/my.disk)
+
+# DRIVERS / PLUGINS:
+
+set(DRIVERS
+  virtionet
+  vmxnet3
+  uplink_log
+  vga_output
+  boot_logger
+  )
+
+set(PLUGINS
+  uplink
+  autoconf
+  system_log
+  )
+
+# THIRD PARTY LIBRARIES:
+
+set(LIBRARIES
+  libliveupdate.a libmana.a # path to full library
+  )
+
+# include service build script
+include($ENV{INCLUDEOS_PREFIX}/includeos/post.service.cmake)
+install_certificates(disk/certs)
+diskbuilder(disk)
+
+# Make sure bucket is downloaded before service is built
+add_dependencies(service bucket)

--- a/tests/skip-acorn/acorn_service/app/acorn
+++ b/tests/skip-acorn/acorn_service/app/acorn
@@ -1,0 +1,43 @@
+// -*-C++-*-
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ACORN_WEB_APPLIANCE
+#define ACORN_WEB_APPLIANCE
+
+#include "models/user.hpp"
+#include "models/squirrel.hpp"
+
+#include "routes/routes"
+
+#include <bucket/bucket.hpp>
+
+#include <mana/dashboard>
+
+#include "../fs/acorn_fs.hpp"
+
+#include <util/logger.hpp>
+
+// Middleware
+#include <mana/middleware/parsley.hpp>
+#include <mana/middleware/director.hpp>
+#include <mana/middleware/butler.hpp>
+#include <mana/middleware/cookie_parser.hpp>
+
+#include <mana/server.hpp>
+
+#endif //< ACORN_WEB_APPLIANCE

--- a/tests/skip-acorn/acorn_service/app/models/squirrel.hpp
+++ b/tests/skip-acorn/acorn_service/app/models/squirrel.hpp
@@ -1,0 +1,192 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef MODEL_SQUIRREL_HPP
+#define MODEL_SQUIRREL_HPP
+
+#include <locale>
+#include <algorithm>
+#include <rtc>
+
+#include <mana/attributes/json.hpp>
+
+namespace acorn {
+
+/**
+ *
+ */
+struct Squirrel : mana::Serializable {
+  size_t key;
+
+  /**
+   *
+   */
+  Squirrel() : key(0), created_at_{RTC::now()}
+  {}
+
+  /**
+   *
+   */
+  Squirrel(const std::string& name, const size_t age, const std::string& occupation)
+    : key         {0}
+    , name_       {name}
+    , age_        {age}
+    , occupation_ {occupation}
+    , created_at_ {RTC::now()}
+  {}
+
+  /**
+   *
+   */
+  const std::string& get_name() const noexcept
+  { return name_; }
+
+  /**
+   *
+   */
+  void set_name(const std::string& name)
+  { name_ = name; }
+
+  /**
+   *
+   */
+  size_t get_age() const noexcept
+  { return age_; }
+
+  /**
+   *
+   */
+  void set_age(const size_t age) noexcept
+  { age_ = age; }
+
+  /**
+   *
+   */
+  const std::string& get_occupation() const noexcept
+  { return occupation_; }
+
+  /**
+   *
+   */
+  void set_occupation(const std::string& occupation)
+  { occupation_ = occupation; }
+
+  /**
+   *
+   */
+  RTC::timestamp_t get_created_at() const noexcept
+  { return created_at_; }
+
+  /**
+   *
+   */
+  std::string json() const;
+
+  /**
+   *
+   */
+  virtual void serialize(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
+
+  /**
+   *
+   */
+  virtual bool deserialize(const rapidjson::Document&) override;
+
+  /**
+   *
+   */
+  bool is_equal(const Squirrel&) const noexcept;
+
+  /**
+   *
+   */
+  static bool is_equal(const Squirrel&, const Squirrel&) noexcept;
+
+private:
+  std::string      name_;
+  size_t           age_;
+  std::string      occupation_;
+  RTC::timestamp_t created_at_;
+}; //< struct Squirrel
+
+/**--v----------- Implementation Details -----------v--**/
+
+inline void Squirrel::serialize(rapidjson::Writer<rapidjson::StringBuffer>& writer) const {
+  writer.StartObject();
+
+  writer.Key("key");
+  writer.Uint(key);
+
+  writer.Key("name");
+  writer.String(name_);
+
+  writer.Key("age");
+  writer.Uint(age_);
+
+  writer.Key("occupation");
+  writer.String(occupation_);
+
+  writer.Key("created_at");
+  long hest = created_at_;
+  struct tm* tt =
+    gmtime (&hest);
+  char datebuf[32];
+  strftime(datebuf, sizeof datebuf, "%FT%TZ", tt);
+  writer.String(datebuf);
+
+  writer.EndObject();
+}
+
+inline bool Squirrel::deserialize(const rapidjson::Document& doc) {
+  name_       = doc["name"].GetString();
+  age_        = doc["age"].GetUint();
+  occupation_ = doc["occupation"].GetString();
+  return true;
+}
+
+inline std::string Squirrel::json() const {
+  using namespace rapidjson;
+  StringBuffer sb;
+  Writer<StringBuffer> writer(sb);
+  serialize(writer);
+  return sb.GetString();
+}
+
+inline bool Squirrel::is_equal(const Squirrel& s) const noexcept {
+  if(name_.size() not_eq s.name_.size()) {
+    return false;
+  }
+
+  return std::equal(name_.begin(), name_.end(), s.name_.begin(), s.name_.end(),
+    [](const auto a, const auto b) { return ::tolower(a) == ::tolower(b);
+  });
+}
+
+inline bool Squirrel::is_equal(const Squirrel& s1, const Squirrel& s2) noexcept {
+  return s1.is_equal(s2);
+}
+
+inline std::ostream& operator << (std::ostream& output_device, const Squirrel& s) {
+  return output_device << s.json();
+}
+
+/**--^----------- Implementation Details -----------^--**/
+
+} //< namespace acorn
+
+#endif //< MODEL_SQUIRREL_HPP

--- a/tests/skip-acorn/acorn_service/app/models/user.hpp
+++ b/tests/skip-acorn/acorn_service/app/models/user.hpp
@@ -1,0 +1,123 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// User med en key (tilsvarer cookie-id)
+//
+// Brukeridentifisering
+//
+// Starte med:
+// Sette en favorittdyr = hest: kommer opp hest på siden
+
+// Se squirrel.hpp
+
+#pragma once
+#ifndef MODEL_USER_HPP
+#define MODEL_USER_HPP
+
+//#include <locale>
+//#include <algorithm>
+
+#include <mana/attributes/json.hpp>
+
+namespace acorn {
+
+/**
+ *
+ */
+struct User : mana::Serializable {
+  size_t key;
+
+  /**
+   *
+   */
+  User() : key{0} {}
+
+  // More constructors here
+
+  /**
+   *
+   */
+  std::string json() const;
+
+  /**
+   *
+   */
+  virtual void serialize(rapidjson::Writer<rapidjson::StringBuffer>&) const override;
+
+  /**
+   *
+   */
+  virtual bool deserialize(const rapidjson::Document&) override;
+
+  /**
+   *
+   */
+  bool is_equal(const User&) const;
+
+  /**
+   *
+   */
+  static bool is_equal(const User&, const User&);
+
+};
+
+/**--v----------- Implementation Details -----------v--**/
+
+inline void User::serialize(rapidjson::Writer<rapidjson::StringBuffer>& writer) const {
+  writer.StartObject();
+
+  writer.Key("key");
+  writer.Uint(key);
+
+  // Write more variables here
+
+  writer.EndObject();
+}
+
+inline bool User::deserialize(const rapidjson::Document& doc) {
+  key = doc["key"].GetUint();
+
+  // set more variables here
+
+  return true;
+}
+
+inline std::string User::json() const {
+  using namespace rapidjson;
+  StringBuffer sb;
+  Writer<StringBuffer> writer(sb);
+  serialize(writer);
+  return sb.GetString();
+}
+
+inline bool User::is_equal(const User& u) const {
+  return key == u.key;
+}
+
+inline bool User::is_equal(const User& u1, const User& u2) {
+  return u1.is_equal(u2);
+}
+
+inline std::ostream& operator << (std::ostream& output_device, const User& u) {
+  return output_device << u.json();
+}
+
+/**--^----------- Implementation Details -----------^--**/
+
+} //< namespace acorn
+
+#endif //< MODEL_USER_HPP

--- a/tests/skip-acorn/acorn_service/app/routes/languages.hpp
+++ b/tests/skip-acorn/acorn_service/app/routes/languages.hpp
@@ -1,0 +1,89 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUTES_LANGUAGES_HPP
+#define ROUTES_LANGUAGES_HPP
+#include <mana/router.hpp>
+#include <mana/attributes/cookie_jar.hpp>
+
+namespace acorn {
+namespace routes {
+
+class Languages : public mana::Router {
+public:
+
+  Languages()
+  {
+    on_get("/english", [](auto req, auto res) {
+      Languages::lang_handler(req, res, "en-US");
+    });
+
+    on_get("/norwegian", [](auto req, auto res) {
+      Languages::lang_handler(req, res, "nb-NO");
+    });
+
+    on_get("/clear", [](auto req, auto res) {
+      Languages::clear(req, res);
+    });
+  }
+
+private:
+
+  static void lang_handler(mana::Request_ptr req, mana::Response_ptr res, const std::string& lang) {
+    using namespace mana;
+
+    if (req->has_attribute<attribute::Cookie_jar>()) {
+      auto req_cookies = req->get_attribute<attribute::Cookie_jar>();
+
+      { // Print all the request-cookies
+        const auto& all_cookies = req_cookies->get_cookies();
+        for (const auto& c : all_cookies) {
+          printf("Cookie: %s=%s\n", c.first.c_str(), c.second.c_str());
+        }
+      }
+
+      const auto& value = req_cookies->cookie_value("lang");
+
+      if (value == "") {
+        printf("%s\n", "Cookie with name 'lang' not found! Creating it.");
+        res->cookie(http::Cookie{"lang", lang});
+      } else if (value not_eq lang) {
+        printf("%s\n", "Cookie with name 'lang' found, but with wrong value. Updating cookie.");
+        res->update_cookie<http::Cookie>("lang", lang);
+      } else {
+        printf("%s%s%s\n", "Wanted cookie already exists (name 'lang' and value '", lang.c_str(), "')!");
+      }
+
+    } else {
+      printf("%s\n", "Request has no cookies! Creating cookie.");
+      res->cookie(http::Cookie{"lang", lang});
+    }
+
+    res->send(true);
+  }
+
+  static void clear(mana::Request_ptr, mana::Response_ptr res) {
+    printf("Clearing cookie!\n");
+    res->clear_cookie<http::Cookie>("lang");
+    res->send(true);
+  }
+};
+
+} // < namespace routes
+} // < namespace acorn
+
+#endif

--- a/tests/skip-acorn/acorn_service/app/routes/routes
+++ b/tests/skip-acorn/acorn_service/app/routes/routes
@@ -1,0 +1,26 @@
+// -*-C++-*-
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUTES_ROUTES
+#define ROUTES_ROUTES
+
+#include "squirrels.hpp"
+#include "users.hpp"
+#include "languages.hpp"
+
+#endif

--- a/tests/skip-acorn/acorn_service/app/routes/squirrels.hpp
+++ b/tests/skip-acorn/acorn_service/app/routes/squirrels.hpp
@@ -1,0 +1,98 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUTES_SQUIRRELS_HPP
+#define ROUTES_SQUIRRELS_HPP
+#include <mana/router.hpp>
+#include <models/squirrel.hpp>
+#include <bucket/bucket.hpp>
+#include <mana/attributes/json.hpp>
+
+namespace acorn {
+namespace routes {
+
+class Squirrels : public mana::Router {
+
+  using SquirrelBucket = bucket::Bucket<Squirrel>;
+
+public:
+
+  Squirrels(std::shared_ptr<SquirrelBucket> squirrels)
+  {
+    // GET /
+    on_get("/",
+    [squirrels] (auto, auto res)
+    {
+      //printf("[Squirrels@GET:/] Responding with content inside SquirrelBucket\n");
+      using namespace rapidjson;
+      StringBuffer sb;
+      Writer<StringBuffer> writer(sb);
+      squirrels->serialize(writer);
+      res->send_json(sb.GetString());
+    });
+
+    // POST /
+    on_post("/",
+    [squirrels] (mana::Request_ptr req, auto res)
+    {
+      using namespace mana;
+      auto json = req->get_attribute<attribute::Json_doc>();
+      if(!json) {
+        res->error({http::Internal_Server_Error, "Server Error", "Server needs to be sprinkled with Parsley"});
+      }
+      else {
+        auto& doc = json->doc();
+        try {
+          // create an empty model
+          acorn::Squirrel s;
+          // deserialize it
+          s.deserialize(doc);
+          // add to bucket
+          auto id = squirrels->capture(s);
+          assert(id == s.key);
+          printf("[Squirrels@POST:/] Squirrel captured: %s\n", s.get_name().c_str());
+          // setup the response
+          // location to the newly created resource
+          using namespace std;
+          res->header().set_field(http::header::Location, std::string(req->uri().path())); // return back end loc i guess?
+          // status code 201 Created
+          res->source().set_status_code(http::Created);
+          // send the created entity as response
+          res->send_json(s.json());
+        }
+        catch(const Assert_error& e) {
+          printf("[Squirrels@POST:/] Assert_error: %s\n", e.what());
+          res->error({"Parsing Error", "Could not parse data."});
+        }
+        catch(const bucket::ConstraintException& e) {
+          printf("[Squirrels@POST:/] ConstraintException: %s\n", e.what());
+          res->error({"Constraint Exception", e.what()});
+        }
+        catch(const bucket::BucketException& e) {
+          printf("[Squirrels@POST:/] BucketException: %s\n", e.what());
+          res->error({"Bucket Exception", e.what()});
+        }
+      }
+    });
+
+  }
+};
+
+} // < namespace routes
+} // < namespace acorn
+
+#endif

--- a/tests/skip-acorn/acorn_service/app/routes/users.hpp
+++ b/tests/skip-acorn/acorn_service/app/routes/users.hpp
@@ -1,0 +1,80 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUTES_USERS_HPP
+#define ROUTES_USERS_HPP
+#include <mana/router.hpp>
+#include <models/user.hpp>
+#include <bucket/bucket.hpp>
+#include <mana/attributes/json.hpp>
+
+namespace acorn {
+namespace routes {
+
+class Users : public mana::Router {
+
+  using UserBucket = bucket::Bucket<User>;
+
+public:
+
+  Users(std::shared_ptr<UserBucket> users)
+  {
+    // GET /
+    on_get("/",
+    [users] (auto, auto res)
+    {
+      printf("[Users@GET:/] Responding with content inside UserBucket\n");
+      using namespace rapidjson;
+      StringBuffer sb;
+      Writer<StringBuffer> writer(sb);
+      users->serialize(writer);
+      res->send_json(sb.GetString());
+    });
+
+    // GET /:id(Digit)/:name/something/:something[Letters]
+    on_get("/:id(\\d+)/:name/something/:something([a-z]+)",
+    [users] (mana::Request_ptr req, auto res)
+    {
+      // Get parameters:
+      // Alt.: std::string id = req->params().get("id");
+      auto& params = req->params();
+      std::string id = params.get("id");
+      std::string name = params.get("name");
+      std::string something = params.get("something");
+
+      // std::string doesntexist = params.get("doesntexist");  // throws ParamException
+
+      printf("id: %s\n", id.c_str());
+      printf("name: %s\n", name.c_str());
+      printf("something: %s\n", something.c_str());
+
+      printf("[Users@GET:/:id(\\d+)/:name/something/:something([a-z]+)] Responding with content inside UserBucket\n");
+      using namespace rapidjson;
+      StringBuffer sb;
+      Writer<StringBuffer> writer(sb);
+      users->serialize(writer);
+      res->send_json(sb.GetString());
+    });
+
+
+  }
+};
+
+} // < namespace routes
+} // < namespace acorn
+
+#endif

--- a/tests/skip-acorn/acorn_service/dependencies.cmake
+++ b/tests/skip-acorn/acorn_service/dependencies.cmake
@@ -1,0 +1,12 @@
+
+include(ExternalProject)
+ExternalProject_Add(bucket
+  GIT_REPOSITORY "https://github.com/includeos/bucket.git"
+  PREFIX bucket
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  )
+
+set(BUCKET_DIR ${CMAKE_CURRENT_BINARY_DIR}/bucket/src/)

--- a/tests/skip-acorn/acorn_service/fs/acorn_fs.cpp
+++ b/tests/skip-acorn/acorn_service/fs/acorn_fs.cpp
@@ -1,0 +1,64 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "acorn_fs.hpp"
+
+namespace acorn {
+
+static size_t dir_count;
+static size_t file_count;
+
+static void
+recursive_fs_dump(const std::vector<fs::Dirent>& entries, const int depth = 1)
+{
+  const int indent = (depth * 3);
+
+  for (auto&& entry : entries) {
+    if (entry.is_dir()) {
+      if (entry.name() not_eq "."  and entry.name() not_eq "..") {
+        ++dir_count;
+        printf("%*c-[ %s ]\n", indent, '+', entry.name().c_str());
+        entry.ls(
+          [depth] (auto, auto entries) {
+            recursive_fs_dump(*entries, (depth + 1));
+          });
+      } else {
+        printf("%*c   %s\n", indent, '+', entry.name().c_str());
+      }
+    } else {
+      printf("%*c-> %s\n", indent, '+', entry.name().c_str());
+      ++file_count;
+    }
+  }
+
+}
+
+void list_static_content(const fs::File_system& fs)
+{
+  printf("%s\n",
+  "================================================================================\n"
+  "STATIC CONTENT LISTING\n"
+  "================================================================================\n");
+  dir_count  = 0;
+  file_count = 0;
+  recursive_fs_dump(*fs.ls("/").entries);
+  printf("\n%u %s, %u %s\n", dir_count, "directories", file_count, "files");
+  printf("%s",
+  "================================================================================\n");
+}
+
+} //< namespace acorn

--- a/tests/skip-acorn/acorn_service/fs/acorn_fs.hpp
+++ b/tests/skip-acorn/acorn_service/fs/acorn_fs.hpp
@@ -1,0 +1,30 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#ifndef ACORN_FS_HPP
+#define ACORN_FS_HPP
+
+#include <memdisk>
+#include <fs/disk.hpp>
+
+namespace acorn
+{
+  void list_static_content(const fs::File_system&);
+}
+
+#endif //< ACORN_FS_HPP

--- a/tests/skip-acorn/acorn_service/nacl.txt
+++ b/tests/skip-acorn/acorn_service/nacl.txt
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/skip-acorn/acorn_service/service.cpp
+++ b/tests/skip-acorn/acorn_service/service.cpp
@@ -1,0 +1,175 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015-2016 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <os>
+#include <acorn>
+
+using namespace std;
+using namespace acorn;
+
+using UserBucket     = bucket::Bucket<User>;
+using SquirrelBucket = bucket::Bucket<Squirrel>;
+
+static std::shared_ptr<UserBucket>     users;
+static std::shared_ptr<SquirrelBucket> squirrels;
+
+static std::unique_ptr<mana::Server> server_;
+static std::unique_ptr<mana::dashboard::Dashboard> dashboard_;
+static std::unique_ptr<Logger> logger_;
+// static content from memdisk
+static fs::Disk_ptr disk;
+
+#include <isotime>
+#include <net/inet>
+
+static void start_acorn(net::Inet& inet)
+{
+  /** SETUP LOGGER */
+  const int LOGBUFFER_LEN = 1024*16;
+  static gsl::span<char> spanerino{new char[LOGBUFFER_LEN], LOGBUFFER_LEN};
+  logger_ = std::make_unique<Logger>(spanerino);
+  logger_->flush();
+  logger_->log("LUL\n");
+
+  OS::add_stdout(
+  [] (const char* data, size_t len) {
+    // append timestamp
+    auto entry = "[" + isotime::now() + "]" + std::string{data, len};
+    logger_->log(entry);
+  });
+
+  disk = fs::shared_memdisk();
+
+  // init the first legit partition/filesystem
+  disk->init_fs(
+  [&inet] (fs::error_t err, auto& fs)
+  {
+      if (err) panic("Could not mount filesystem...\n");
+
+      // only works with synchronous disks (memdisk)
+      list_static_content(fs);
+
+      /** BUCKET SETUP */
+
+      // create squirrel bucket
+      squirrels = std::make_shared<SquirrelBucket>(10);
+      // set member name to be unique
+      squirrels->add_index<std::string>("name",
+      [](const Squirrel& s)->const auto&
+      {
+        return s.get_name();
+      }, SquirrelBucket::UNIQUE);
+
+      // seed squirrels
+      squirrels->spawn("Alfred"s,  1000U, "Wizard"s);
+      squirrels->spawn("Alf"s,     6U,    "Script Kiddie"s);
+      squirrels->spawn("Andreas"s, 28U,   "Code Monkey"s);
+      squirrels->spawn("AnnikaH"s, 20U,   "Fairy"s);
+      squirrels->spawn("Ingve"s,   24U,   "Integration Master"s);
+      squirrels->spawn("Martin"s,  16U,   "Build Master"s);
+      squirrels->spawn("Rico"s,    28U,   "Mad Scientist"s);
+
+      // setup users bucket
+      users = std::make_shared<UserBucket>();
+      users->spawn();
+      users->spawn();
+
+      /** ROUTES SETUP **/
+      using namespace mana;
+      Router router;
+
+      // setup Squirrel routes
+      router.use("/api/squirrels", routes::Squirrels{squirrels});
+      // setup User routes
+      router.use("/api/users", routes::Users{users});
+      // setup Language routes
+      router.use("/api/languages", routes::Languages{});
+
+
+      /** DASHBOARD SETUP **/
+      dashboard_ = std::make_unique<dashboard::Dashboard>(8192);
+      // Add singleton component
+      dashboard_->add(dashboard::Memmap::instance());
+      dashboard_->add(dashboard::StackSampler::instance());
+      dashboard_->add(dashboard::Status::instance());
+      // Construct component
+      dashboard_->construct<dashboard::Statman>(Statman::get());
+      dashboard_->construct<dashboard::TCP>(inet.tcp());
+      dashboard_->construct<dashboard::CPUsage>();
+      dashboard_->construct<dashboard::Logger>(*logger_, static_cast<size_t>(50));
+
+      // Add Dashboard routes to "/api/dashboard"
+      router.use("/api/dashboard", dashboard_->router());
+
+      // Fallback route for angular application - serve index.html if route is not found
+      router.on_get("/app/.*",
+      [&fs](auto, auto res) {
+        #ifdef VERBOSE_WEBSERVER
+        printf("[@GET:/app/*] Fallback route - try to serve index.html\n");
+        #endif
+        fs.cstat("/public/app/index.html", [res](auto err, const auto& entry) {
+          if(err) {
+            res->send_code(http::Not_Found);
+          } else {
+            // Serve index.html
+            #ifdef VERBOSE_WEBSERVER
+            printf("[@GET:/app/*] (Fallback) Responding with index.html. \n");
+            #endif
+            res->send_file({disk, entry});
+          }
+        });
+      });
+      INFO("Router", "Registered routes:\n%s", router.to_string().c_str());
+
+
+      /** SERVER SETUP **/
+      server_ = std::make_unique<Server>(inet.tcp());
+      // set routes and start listening
+      server_->set_routes(router).listen(80);
+
+
+      /** MIDDLEWARE SETUP **/
+      // custom middleware to serve static files
+      auto opt = {"index.html"};
+      Middleware_ptr butler = std::make_shared<middleware::Butler>(disk, "/public", opt);
+      server_->use(butler);
+
+      // custom middleware to serve a webpage for a directory
+      Middleware_ptr director = std::make_shared<middleware::Director>(disk, "/public/static");
+      server_->use("/static", director);
+
+      Middleware_ptr parsley = std::make_shared<middleware::Parsley>();
+      server_->use(parsley);
+
+      Middleware_ptr cookie_parser = std::make_shared<middleware::Cookie_parser>();
+      server_->use(cookie_parser);
+
+    }); // < disk
+
+}
+
+void Service::start()
+{
+  auto& inet = net::Super_stack::get(0);
+  if (not inet.is_configured())
+  {
+    inet.on_config(start_acorn);
+  }
+  else {
+    start_acorn(inet);
+  }
+}

--- a/tests/skip-acorn/hey-acorn.sh
+++ b/tests/skip-acorn/hey-acorn.sh
@@ -1,0 +1,27 @@
+# hey acorn http testing
+# Script used for performing http requests
+# Returns rate and average response time
+
+# Input values to cmd
+sent=10000
+concurrency=200
+cmdOut=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30:80)
+
+# Parse output, important to set a default value if the command over fails
+received=$(printf "%s" "$cmdOut" | awk '/responses/ {print $2}' )
+if [ -z $received ]; then received=0; fi
+rate=$(printf "%s" "$cmdOut" | awk '/Requests\/sec/ {print $2}' )
+if [ -z $rate ]; then rate=0; fi
+avg=$(printf "%s" "$cmdOut" | awk '/Average/ {print $2}' )
+if [ -z $avg ]; then avg=0; fi
+
+jq  --arg dataSent $sent \
+    --arg dataReceived $received \
+    --arg dataRate $rate \
+    --arg dataAvg $avg \
+    --arg dataFull "$cmdOut" \
+    '. | .["sent"]=($dataSent|tonumber) |
+    .["received"]=($dataReceived|tonumber) |
+    .["rate"]=($dataRate|tonumber) |
+    .["avg"]=($dataAvg|tonumber) |
+    .["raw"]=$dataFull'<<<'{}'

--- a/tests/skip-acorn/install_hey.sh
+++ b/tests/skip-acorn/install_hey.sh
@@ -1,0 +1,1 @@
+docker pull rcmorano/docker-hey

--- a/tests/skip-acorn/interface-not-used.nacl
+++ b/tests/skip-acorn/interface-not-used.nacl
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/skip-acorn/testspec.json
+++ b/tests/skip-acorn/testspec.json
@@ -1,0 +1,12 @@
+{
+    "customservicepath": "acorn_service",
+    "deploy": false,
+    "clientcommandscript": "hey-acorn.sh",
+    "setup": {
+        "client1": "install_hey.sh"
+    },
+    "level1": 1,
+    "level2": 2,
+    "level3": 3
+  }
+  

--- a/tests/skip-demo/demo_service/CMakeLists.txt
+++ b/tests/skip-demo/demo_service/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+# IncludeOS install location
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
+endif()
+
+# Use toolchain (if needed)
+include($ENV{INCLUDEOS_PREFIX}/includeos/pre.service.cmake)
+
+# Name of your project
+project (demo_service)
+
+# Human-readable name of your service
+set(SERVICE_NAME "IncludeOS Demo Service")
+
+# Name of your service binary
+set(BINARY       "demo_service")
+
+# Source files to be linked with OS library parts to form bootable image
+set(SOURCES
+  service.cpp # ...add more here
+  )
+
+#
+# Service CMake options
+# (uncomment to enable)
+#
+
+# MISC:
+
+# To add your own include paths:
+# set(LOCAL_INCLUDES ".")
+
+# Adding memdisk (expects my.disk to exist in current dir):
+# set(MEMDISK ${CMAKE_SOURCE_DIR}/my.disk)
+
+# DRIVERS / PLUGINS:
+
+set(DRIVERS
+  virtionet
+  vmxnet3
+  uplink_log
+  vga_output
+  boot_logger
+  )
+
+set(PLUGINS
+  uplink
+  autoconf
+  system_log
+  )
+
+# THIRD PARTY LIBRARIES:
+
+set(LIBRARIES
+  libliveupdate.a  # path to full library
+  )
+
+
+# include service build script
+include($ENV{INCLUDEOS_PREFIX}/includeos/post.service.cmake)
+install_certificates(disk/certs)
+diskbuilder(disk)

--- a/tests/skip-demo/demo_service/nacl.txt
+++ b/tests/skip-demo/demo_service/nacl.txt
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/skip-demo/demo_service/service.cpp
+++ b/tests/skip-demo/demo_service/service.cpp
@@ -1,0 +1,133 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath> // rand()
+#include <sstream>
+
+#include <os>
+#include <net/inet>
+#include <timers>
+#include <net/http/request.hpp>
+#include <net/http/response.hpp>
+
+using namespace std::chrono;
+
+std::string HTML_RESPONSE()
+{
+  const int color = rand();
+
+  // Generate some HTML
+  std::stringstream stream;
+  stream << "<!DOCTYPE html><html><head>"
+         << "<link href='https://fonts.googleapis.com/css?family=Ubuntu:500,300'"
+         << " rel='stylesheet' type='text/css'>"
+         << "<title>IncludeOS Demo Service</title></head><body>"
+         << "<h1 style='color: #" << std::hex << ((color >> 8) | 0x020202)
+         << "; font-family: \"Arial\", sans-serif'>"
+         << "Include<span style='font-weight: lighter'>OS</span></h1>"
+         << "<h2>The C++ Unikernel</h2>"
+         << "<p>You have successfully booted an IncludeOS TCP service with simple http. "
+         << "For a more sophisticated example, take a look at "
+         << "<a href='https://github.com/hioa-cs/IncludeOS/tree/master/examples/acorn'>Acorn</a>.</p>"
+         << "<footer><hr/>&copy; 2017 IncludeOS </footer></body></html>";
+
+  return stream.str();
+}
+
+http::Response handle_request(const http::Request& req)
+{
+  printf("<Service> Request:\n%s\n", req.to_string().c_str());
+
+  http::Response res;
+
+  auto& header = res.header();
+
+  header.set_field(http::header::Server, "IncludeOS/0.10");
+
+  // GET /
+  if(req.method() == http::GET && req.uri().to_string() == "/")
+  {
+    // add HTML response
+    res.add_body(HTML_RESPONSE());
+
+    // set Content type and length
+    header.set_field(http::header::Content_Type, "text/html; charset=UTF-8");
+    header.set_field(http::header::Content_Length, std::to_string(res.body().size()));
+  }
+  else
+  {
+    // Generate 404 response
+    res.set_status_code(http::Not_Found);
+  }
+
+  header.set_field(http::header::Connection, "close");
+
+  return res;
+}
+
+void Service::start()
+{
+  // Get the first IP stack
+  // It should have configuration from config.json
+  auto& inet = net::Super_stack::get(0);
+
+  // Print some useful netstats every 30 secs
+  Timers::periodic(5s, 30s,
+  [&inet] (uint32_t) {
+    printf("<Service> TCP STATUS:\n%s\n", inet.tcp().status().c_str());
+  });
+
+  // Set up a TCP server on port 80
+  auto& server = inet.tcp().listen(80);
+
+  // Add a TCP connection handler - here a hardcoded HTTP-service
+  server.on_connect(
+  [] (net::tcp::Connection_ptr conn) {
+    printf("<Service> @on_connect: Connection %s successfully established.\n",
+      conn->remote().to_string().c_str());
+    // read async with a buffer size of 1024 bytes
+    // define what to do when data is read
+    conn->on_read(1024,
+    [conn] (auto buf)
+    {
+      printf("<Service> @on_read: %lu bytes received.\n", buf->size());
+      try
+      {
+        const std::string data((const char*) buf->data(), buf->size());
+        // try to parse the request
+        http::Request req{data};
+
+        // handle the request, getting a matching response
+        auto res = handle_request(req);
+
+        printf("<Service> Responding with %u %s.\n",
+          res.status_code(), http::code_description(res.status_code()).data());
+
+        conn->write(res);
+      }
+      catch(const std::exception& e)
+      {
+        printf("<Service> Unable to parse request:\n%s\n", e.what());
+      }
+    });
+    conn->on_write([](size_t written) {
+      printf("<Service> @on_write: %lu bytes written.\n", written);
+    });
+  });
+
+  printf("*** Basic demo service started ***\n");
+}

--- a/tests/skip-demo/hey-demo.sh
+++ b/tests/skip-demo/hey-demo.sh
@@ -1,0 +1,27 @@
+# hey demo (service) http testing
+# Script used for performing http requests
+# Returns rate and average response time
+
+# Input values to cmd
+sent=10000
+concurrency=200
+cmdOut=$(docker run --rm rcmorano/docker-hey -n $sent -c $concurrency http://10.100.0.30:80)
+
+# Parse output, important to set a default value if the command over fails
+received=$(printf "%s" "$cmdOut" | awk '/responses/ {print $2}' )
+if [ -z $received ]; then received=0; fi
+rate=$(printf "%s" "$cmdOut" | awk '/Requests\/sec/ {print $2}' )
+if [ -z $rate ]; then rate=0; fi
+avg=$(printf "%s" "$cmdOut" | awk '/Average/ {print $2}' )
+if [ -z $avg ]; then avg=0; fi
+
+jq  --arg dataSent $sent \
+    --arg dataReceived $received \
+    --arg dataRate $rate \
+    --arg dataAvg $avg \
+    --arg dataFull "$cmdOut" \
+    '. | .["sent"]=($dataSent|tonumber) |
+    .["received"]=($dataReceived|tonumber) |
+    .["rate"]=($dataRate|tonumber) |
+    .["avg"]=($dataAvg|tonumber) |
+    .["raw"]=$dataFull'<<<'{}'

--- a/tests/skip-demo/install_hey.sh
+++ b/tests/skip-demo/install_hey.sh
@@ -1,0 +1,1 @@
+docker pull rcmorano/docker-hey

--- a/tests/skip-demo/interface-not-used.nacl
+++ b/tests/skip-demo/interface-not-used.nacl
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/skip-demo/testspec.json
+++ b/tests/skip-demo/testspec.json
@@ -1,0 +1,12 @@
+{
+    "customservicepath": "demo_service",
+    "deploy": false,
+    "clientcommandscript": "hey-demo.sh",
+    "setup": {
+        "client1": "install_hey.sh"
+    },
+    "level1": 1,
+    "level2": 2,
+    "level3": 3
+  }
+  

--- a/tests/skip-udp/install_nmap.sh
+++ b/tests/skip-udp/install_nmap.sh
@@ -1,0 +1,2 @@
+sudo apt-get update
+sudo apt-get install -y nmap

--- a/tests/skip-udp/interface-not-used.nacl
+++ b/tests/skip-udp/interface-not-used.nacl
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/skip-udp/testspec.json
+++ b/tests/skip-udp/testspec.json
@@ -1,0 +1,11 @@
+{
+    "customservicepath": "udp_service",
+    "deploy": false,
+    "clientcommandscript": "udp_nping.sh",
+    "setup": {
+        "client1": "install_nmap.sh"
+    },
+    "level1": 1,
+    "level2": 2,
+    "level3": 3
+}

--- a/tests/skip-udp/udp_nping.sh
+++ b/tests/skip-udp/udp_nping.sh
@@ -1,0 +1,24 @@
+# Basically: nping --udp -p 4242 10.100.0.30 --data hei
+
+sent=1000
+rate=100 # Requests pr second, higher than 5 requires sudo
+mode="--udp"
+port=4242
+# delay=
+data="hi"
+
+cmdOut=$(nping -c $sent $mode -p $port --rate $rate --data $data 10.100.0.30)
+res=$(printf "%s" "$cmdOut" | grep "Successful connections:")
+# attempts=$(printf "%s" "$res" | cut -d ' ' -f 4)
+received=$(printf "%s" "$res" | cut -d ' ' -f 8)
+# successful=$(printf "%s" "$res" | cut -d ' ' -f 8)
+# failed=$(printf "%s" "$res" | cut -d ' ' -f 11)
+
+jq  --arg dataSent $sent \
+    --arg dataReceived $received \
+    --arg dataRate $rate \
+    --arg dataFull "$cmdOut" \
+    '. | .["sent"]=($dataSent|tonumber) |
+    .["received"]=($dataReceived|tonumber) |
+    .["rate"]=($dataRate|tonumber) |
+    .["raw"]=$dataFull'<<<'{}'

--- a/tests/skip-udp/udp_service/CMakeLists.txt
+++ b/tests/skip-udp/udp_service/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+# IncludeOS install location
+if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
+  set(ENV{INCLUDEOS_PREFIX} /usr/local)
+endif()
+
+# Use toolchain (if needed)
+include($ENV{INCLUDEOS_PREFIX}/includeos/pre.service.cmake)
+
+# Name of your project
+project (udp_service)
+
+# Human-readable name of your service
+set(SERVICE_NAME "IncludeOS UDP Service")
+
+# Name of your service binary
+set(BINARY       "udp_service")
+
+# Source files to be linked with OS library parts to form bootable image
+set(SOURCES
+  service.cpp # ...add more here
+  )
+
+#
+# Service CMake options
+# (uncomment to enable)
+#
+
+# MISC:
+
+# To add your own include paths:
+# set(LOCAL_INCLUDES ".")
+
+# Adding memdisk (expects my.disk to exist in current dir):
+# set(MEMDISK ${CMAKE_SOURCE_DIR}/my.disk)
+
+# DRIVERS / PLUGINS:
+
+set(DRIVERS
+  virtionet
+  vmxnet3
+  uplink_log
+  vga_output
+  boot_logger
+  )
+
+set(PLUGINS
+  uplink
+  autoconf
+  system_log
+  )
+
+# THIRD PARTY LIBRARIES:
+
+set(LIBRARIES
+  libliveupdate.a  # path to full library
+  )
+
+
+# include service build script
+include($ENV{INCLUDEOS_PREFIX}/includeos/post.service.cmake)
+install_certificates(disk/certs)
+diskbuilder(disk)

--- a/tests/skip-udp/udp_service/nacl.txt
+++ b/tests/skip-udp/udp_service/nacl.txt
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/skip-udp/udp_service/service.cpp
+++ b/tests/skip-udp/udp_service/service.cpp
@@ -1,0 +1,45 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2018 IncludeOS AS, Oslo, Norway
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <service>
+#include <net/inet>
+#include <timers>
+
+using namespace net;
+
+void Service::start() {
+    auto& inet = net::Super_stack::get(0);
+    const UDP::port_t port = 4242;
+    auto& sock = inet.udp().bind(port);
+
+    // When getting UDP data
+    sock.on_read([&sock] (UDP::addr_t addr, UDP::port_t port,
+        const char* data, size_t len)
+    {
+        std::string strdata(data, len);
+        INFO("UDP service", "Getting UDP data from %s:%d %s",
+            addr.to_string().c_str(), port, strdata.c_str());
+
+        // Send the same data right back
+        using namespace std::chrono;
+        Timers::oneshot(100ms, Timers::handler_t::make_packed([&sock, addr, port, data, len](Timers::id_t) {
+            INFO("UDP service", "Sending UDP reply to %s:%d", addr.to_string().c_str(), port);
+            sock.sendto(addr, port, data, len);
+        }));
+    });
+
+    INFO("UDP service", "Listening on port %d", port);
+}

--- a/tests/upgrade/interface.nacl
+++ b/tests/upgrade/interface.nacl
@@ -1,0 +1,7 @@
+Iface outside {
+    address: 10.100.0.30,
+    netmask: 255.255.255.128,
+    gateway: 10.100.0.1,
+    dns: 1.1.1.1,
+    index: 0
+}

--- a/tests/upgrade/testspec.json
+++ b/tests/upgrade/testspec.json
@@ -1,0 +1,7 @@
+{
+    "hostcommandscript": "upgrade.sh",
+    "deploy": false,
+    "level1": 1,
+    "level2": 2,
+    "level3": 3
+}

--- a/tests/upgrade/upgrade.sh
+++ b/tests/upgrade/upgrade.sh
@@ -1,0 +1,61 @@
+# upgrade script
+# Script used for checking that upgrading an instance works (build image and deploy)
+set -e
+
+moth="{{.MothershipBinPathAndName}}"
+instAlias={{.OriginalAlias}}
+instID=$($moth inspect-instance $instAlias -o id)
+naclID=$($moth push-nacl tests/upgrade/interface.nacl -o id)
+
+sent=1
+received=0
+# Upgrade with the pushed nacl
+cmdOut=$($moth upgrade $instID --nacl $naclID --waitAndPrintImageID)
+sleep 0.5
+# Check if the instance now reports this new nacl:
+cmdOut+=$($moth inspect-instance $instID -o json | jq -r '.naclId')
+if [[ "$cmdOut" == *"$naclID"* ]]; then
+    received=$[$received + 1]
+fi
+
+sent=$[$sent + 1]
+# Upgrade without specifying nacl (the previously used nacl should be used again)
+cmdOut+=$($moth upgrade $instID --waitAndPrintImageID)
+sleep 0.5
+# Check if the instance reports the same nacl:
+cmdOut+=$($moth inspect-instance $instID -o json | jq -r '.naclId')
+if [[ "$cmdOut" == *"$naclID"* ]]; then
+    received=$[$received + 1]
+fi
+
+sent=$[$sent + 1]
+# Upgrade and specify service (Starbase is the only possible service for now)
+cmdOut+=$($moth upgrade $instID --service Starbase --waitAndPrintImageID)
+received=$[$received + 1]
+
+sleep 0.5
+sent=$[$sent + 1]
+customTag="mycustomtag"
+# Upgrade and give the image a tag that the instance will report back
+cmdOut+=$($moth upgrade $instID --service Starbase --imageTag $customTag --waitAndPrintImageID)
+sleep 0.5
+# Check if the instance now reports this new imageTag:
+cmdOut+=$($moth inspect-instance $instID -o json | jq -r '.tag')
+if [[ "$cmdOut" == *"$customTag"* ]]; then
+    received=$[$received + 1]
+fi
+
+# If none of the commands above failed it means that we were successful
+rate=0.1
+avg=0
+
+jq  --arg dataSent $sent \
+    --arg dataReceived $received \
+    --arg dataRate $rate \
+    --arg dataAvg $avg \
+    --arg dataFull "$cmdOut" \
+    '. | .["sent"]=($dataSent|tonumber) |
+    .["received"]=($dataReceived|tonumber) |
+    .["rate"]=($dataRate|tonumber) |
+    .["avg"]=($dataAvg|tonumber) |
+    .["raw"]=$dataFull'<<<'{}'


### PR DESCRIPTION
Adding possibility of skipping tests based on the test folder name (if the name starts with "skip", skip it and display a warning)

Adding acorn, udp and demo service tests. These are however added as skip-tests because the functionality we want is not available yet in Lotto (we want to deploy a custom service to the starbase and then run the sh-script in the test as a client command (from lotto-client1))