### PR TITLE
deploy test: Updating deploy script to continue to deploy image after up to 60 seconds

### DIFF
--- a/tests/deploy/deploy.sh
+++ b/tests/deploy/deploy.sh
@@ -17,11 +17,25 @@ for i in {1..100}
 do
     sent=$[$sent + 1]
     # Deploy
-    cmdOut+=$($moth deploy $instID $imgID --wait)
-    # Check if the instance now runs the image (note that this will be the same imageId every time):
-    cmdOut+=$($moth inspect-instance $instID -o json | jq -r '.imageId')
-    if [[ "$cmdOut" == *"$imgID"* ]]; then
-        received=$[$received + 1]
+    if cmdOut=$($moth deploy $instID $imgID --wait); then
+        # Check if the instance now runs the image (note that this will be the same imageId every time):
+        cmdOut+=$($moth inspect-instance $instID -o json | jq -r '.imageId')
+        if [[ "$cmdOut" == *"$imgID"* ]]; then
+            received=$[$received + 1]
+        fi
+    else
+        # Wait up to 1 minute to see if the instance connects back, else finish the test
+        for i in {1..60}; do
+            sleep 1
+            statusNow=$($moth inspect-instance $instID -o json | jq -r '.status')
+            if [ "$statusNow" == "connected" ]; then
+                # break out of THIS for-loop and continue the test
+                break
+            else
+                # break out of both for-loops (end test)
+                break 2
+            fi
+        done
     fi
 done
 


### PR DESCRIPTION
(If the deploy cmd should fail)
If the instance does not connect back in that time, end test.